### PR TITLE
Don't convert abbr & dfn to italics marking. It doesn't make sense, a…

### DIFF
--- a/ppcomp/ppcomp.py
+++ b/ppcomp/ppcomp.py
@@ -44,8 +44,8 @@ PG_EBOOK_START = '*** START OF'
 PG_EBOOK_END = '*** END OF'
 DEFAULT_TRANSFORM_CSS = '''
   /* Italics */
-  i::before, cite::before, em::before, abbr::before, dfn::before,
-  i::after, cite::after, em::after, abbr::after, dfn::after { content: "_"; }
+  i::before, cite::before, em::before,
+  i::after, cite::after, em::after { content: "_"; }
 
   /* Add spaces around td tags */
   td::before, td::after { content: " "; }


### PR DESCRIPTION
…nd causes more miscompares.