### PR TITLE
Remove character_checks() proofing file check

### DIFF
--- a/ppcomp/ppcomp.py
+++ b/ppcomp/ppcomp.py
@@ -44,8 +44,8 @@ PG_EBOOK_START = '*** START OF'
 PG_EBOOK_END = '*** END OF'
 DEFAULT_TRANSFORM_CSS = '''
   /* Italics */
-  i::before, cite::before, em::before, abbr::before, dfn::before,
-  i::after, cite::after, em::after, abbr::after, dfn::after { content: "_"; }
+  i::before, cite::before, em::before,
+  i::after, cite::after, em::after { content: "_"; }
 
   /* Add spaces around td tags */
   td::before, td::after { content: " "; }

--- a/ppcomp/ppcomp.py
+++ b/ppcomp/ppcomp.py
@@ -999,9 +999,6 @@ class PPComp:
         This is used for instance if one version uses curly quotes while the other uses straight.
         In that case, we need to convert one into the other, to get a smaller diff.
         """
-        if not PgdpFile.pgdp_file:
-            return
-
         character_checks = {
             '’': "'",  # close curly single quote to straight
             '‘': "'",  # open curly single quote to straight


### PR DESCRIPTION
I had made the downgrading of chars apply only with files from rounds, but many PPers at least use em-dashes in html and double hyphens in text.