### PR TITLE
Change from stderror to normal so web handler will show it

### DIFF
--- a/ppcomp/ppcomp.py
+++ b/ppcomp/ppcomp.py
@@ -509,7 +509,7 @@ class PgdpFileHtml(PgdpFile):
             raise SyntaxError('File cannot be parsed: ' + filename) from ex
         if errors:
             for error in errors:
-                print(error, file=sys.stderr)
+                print(error)
             raise SyntaxError('Parsing errors in document: ' + filename)
 
         # save line number of <body> tag - actual text start


### PR DESCRIPTION
This SHOULD allow the PHP code to properly display the list of parse errors.